### PR TITLE
Fix for `hsv` mode syntax in Docs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -86,7 +86,7 @@ If Iris is attached to an `input` element, it will first try to pick up its `val
 
 ### mode
 
-Iris can sport a variety of looks. She supports `hsl` and 'hsv' modes depending on your needs.
+Iris can sport a variety of looks. She supports `hsl` and `hsv` modes depending on your needs.
 
 ### controls
 


### PR DESCRIPTION
![screen shot 2013-09-08 at 3 52 34 pm](https://f.cloud.github.com/assets/613826/1103927/fd3f836c-18d0-11e3-849a-3da236a0696e.PNG)
