### PR TITLE
Errors in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks( 'grunt-contrib-concat' );
 
   // Default task.
-  grunt.registerTask('default', 'jshint qunit uglify concat'.split(' ') );
+  grunt.registerTask('default', 'jshint qunit concat uglify'.split(' ') );
 
 };


### PR DESCRIPTION
I ran into some issues trying to run the build proccess.

1- When running the `concat.dist` and `concat.basic` tasks, the files `src/iris.js` and  `src/iris-basic.js` were not propery compiled due to the stray `>` in the filename
2- The uglify task created the minified scripts from the concatenated scripts. However the uglify task was run before the concat task. Running `grunt` once would create empty minified files. (running twice - created it OK)
