### PR TITLE
Redundant and wrong css "top: none" property

### DIFF
--- a/src/iris.css
+++ b/src/iris.css
@@ -132,7 +132,6 @@ input + .iris-picker {
 	height: auto;
 	background: transparent;
 	border: none;
-	top: none;
 	border-radius: 0;
 }
 .iris-picker .iris-square-handle {


### PR DESCRIPTION
For the selector `.iris-picker .iris-slider-offset`, you are already setting top position as 11px and later on line 135, you are setting "top: none" which is redundant and rather wrong
