### PR TITLE
Remove accidentally sexual language

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
 <h2 id="usage">Usage</h2>
 
-<p>Iris is easy to use. She&#8217;s cooperative that way. The easiest thing is to assign her to an <code>input</code> element. Say you have:</p>
+<p>Iris is easy to use. The easiest thing is to assign her to an <code>input</code> element. Say you have:</p>
 
 <pre><code class="lang-markup">&lt;input type=&quot;text&quot; id='color-picker' value=&quot;#bada55&quot; /&gt;
 </code></pre>
@@ -132,7 +132,7 @@
 
 <h3 id="controls">controls</h3>
 
-<p>Iris is flexible like a gymnast. You can change all 3 directions of her controls. Just make sure you cover all 3 aspects of <code>hsl</code> or <code>hsv</code> that you chose in the <a href="#mode">mode</a> option. <code>horiz</code> and &#8216;vert&#8217; sets the horizontal and vertical aspects of the square, respectively, while the <code>strip</code> options sets the rightmost strip.</p>
+<p>Iris is flexible. You can change all 3 directions of her controls. Just make sure you cover all 3 aspects of <code>hsl</code> or <code>hsv</code> that you chose in the <a href="#mode">mode</a> option. <code>horiz</code> and &#8216;vert&#8217; sets the horizontal and vertical aspects of the square, respectively, while the <code>strip</code> options sets the rightmost strip.</p>
 
 <h3 id="hide">hide</h3>
 


### PR DESCRIPTION
Gendering the software is a bit odd, and making it female is going to lead to awkward implications. One pair of sentences might lead a reader to believe that a joke is being made about "using" women (for sex), while the gymnast language might lead a reader to believe that the joke is being continued. These proposed changes make such an inference implausible, I think.

I recommend eliminating the gendered language entirely, which allows you to avoid anybody inferring anything that you didn't mean to imply. No need to get awkward turns of phrase get in the way of good software! :)
